### PR TITLE
Fixes what I think is a bug in the MetricsListener.

### DIFF
--- a/src/metrics/Reporting/HumanReadableReportFormatter.cs
+++ b/src/metrics/Reporting/HumanReadableReportFormatter.cs
@@ -7,7 +7,7 @@ namespace metrics.Reporting
 {
     public class HumanReadableReportFormatter : IReportFormatter
     {
-        public string GetSample()
+        public virtual string GetSample()
         {
             var sb = new StringBuilder();
             var now = DateTime.Now;


### PR DESCRIPTION
When we close the HttpListener that backs the MetricsListener, the
blocking call to GetContext is interrupted and throws an exception.
Adding a catch block to block it and not let it propagate through.