### PR TITLE
EnableReporting method added to metrics class to enable use of any imple...

### DIFF
--- a/src/metrics/Metrics.cs
+++ b/src/metrics/Metrics.cs
@@ -350,6 +350,17 @@ namespace metrics
         public  void EnableConsoleReporting(long period, TimeUnit unit)
         {
             var reporter = new ConsoleReporter(this);
+            EnableReporting(reporter, period, unit);
+        }
+
+        /// <summary>
+        ///  Enables a reporter to run with the specified interval between outputs
+        /// </summary>
+        /// <param name="reporter"></param>
+        /// <param name="period">The period between successive outputs</param>
+        /// <param name="unit">The time unit of the period</param>
+        public void EnableReporting(ReporterBase reporter, long period, TimeUnit unit)
+        {
             reporter.Start(period, unit);
         }
 


### PR DESCRIPTION
...mentation of the ReporterBase class

Reporters can be used both through the Metrics class or, in the case of console reporters, by calling the EnableConsoleReporter method. This change allows for any reporter to be used through the Metrics class. By using the EnableReporting method the use of a reporter in conjunction with the Metrics class the calling class does not need any knowledge of how the two classes operate together. This makes the Metrics class more encapsulated and de-couples the calling class from its inner workings.

For example, creating an implemention of ReporterBase for DataDog, and this will allow for simply passing that implementation without Metric.NET having any knowledge of it.